### PR TITLE
Fix: Specify minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "https://github.com/ropin13/hackmd-export/issues"
   },
   "homepage": "https://github.com/ropin13/hackmd-export#readme",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "axios": "^1.9.0",
     "yargs": "^18.0.0"


### PR DESCRIPTION
Added an `engines` field to `package.json` to require Node.js version 20 or higher.

This resolves an issue where `npx` would attempt to use an incompatible older version of Node.js, causing errors with dependencies like `yargs-parser` that require a more recent Node.js version.